### PR TITLE
Create robots.txt

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Compile documentation to HTML
       run: |
         sphinx-build -W -b html source build
+        mv source/robots.txt build/robots.txt
     - name: Deploy to Pages
       id: deploy
       uses: cloudflare/pages-action@1

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /en


### PR DESCRIPTION
google wants to index /en/whatever because we used to use rtd

make it stop doing that